### PR TITLE
add universe discovery interval to sender options

### DIFF
--- a/examples/sender/sender.go
+++ b/examples/sender/sender.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	log.Println("Hello")
 
-	sender, err := sacn.NewSender("192.168.1.200", &sacn.SenderOptions{}) // Create sender
+	sender, err := sacn.NewSender("192.168.1.200", &sacn.SenderOptions{UnivDiscInt: 1}) // Create sender
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The predefined 10s interval between discovery packets may not suit all use cases. Also, the first discovery packet should be sent as soon as the sender is ready.